### PR TITLE
python3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Role Variables
 --------------
 
 ```
-dockerpy_version: 1.8.0
+ansible_python_interpreter: "/usr/bin/python3"
+dockerpy_version: 4.2.0
 docker_registries: []
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
-dockerpy_version: 1.10.6
+ansible_python_interpreter: "/usr/bin/python3"
+dockerpy_version: 4.2.0
 docker_registries: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,8 @@
 
 - name: Install docker-py
   pip:
-    name: docker-py
+    executable: pip3
+    name: docker
     version : "{{dockerpy_version}}"
   become: yes
 


### PR DESCRIPTION
added default ansible_python_interpreter value as "/usr/bin/python3"
dockerpy_version changed to 4.2.0 for python3